### PR TITLE
[DELIVERS 4075] allows for callback and controlled date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 0.3.0 - 2019-5-22
+### Added
+- Allows for controlled selectedDate
+- Allows for callback on navigation change (returns date)
+
 ## 0.2.0 - 2018-11-27
 ### Removed
 - Unused dependencies

--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,7 @@ type PropsType = {
   events: CalendarEventType[],
   onSelectEvent(event: CalendarEventType): void,
   onSelectSlot(event: CalendarEventType): void,
-  onNavigate(date: Date): void,
+  onNavigate?: (date: Date) => void,
   date?: string,
   className: string,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -135,10 +135,11 @@ class Schedule extends Component<PropsType, StateType> {
       events,
       onSelectSlot,
       onSelectEvent,
-      onNavigate,
+      onNavigate = () => { },
       date,
     } = this.props;
     const { selectedDate } = this.state;
+
     return (
       <BigCalendar
         className={className}

--- a/src/index.js
+++ b/src/index.js
@@ -111,6 +111,8 @@ type PropsType = {
   events: CalendarEventType[],
   onSelectEvent(event: CalendarEventType): void,
   onSelectSlot(event: CalendarEventType): void,
+  onNavigate(date: Date): void,
+  date?: string,
   className: string,
 };
 
@@ -128,9 +130,15 @@ class Schedule extends Component<PropsType, StateType> {
   };
 
   render() {
-    const { className, events, onSelectSlot, onSelectEvent } = this.props;
+    const {
+      className,
+      events,
+      onSelectSlot,
+      onSelectEvent,
+      onNavigate,
+      date,
+    } = this.props;
     const { selectedDate } = this.state;
-
     return (
       <BigCalendar
         className={className}
@@ -144,9 +152,9 @@ class Schedule extends Component<PropsType, StateType> {
         step={15}
         timeslots={4}
         scrollToTime={scrollTarget}
-        date={selectedDate}
+        date={date || selectedDate}
         getNow={() => new Date()}
-        onNavigate={() => {}} // required for some reason
+        onNavigate={onNavigate}
         onSelectEvent={onSelectEvent}
         onSelectSlot={onSelectSlot}
         components={{


### PR DESCRIPTION
this was need to for the cal view on smb-admin to fix fetching issues with sessions not showing up
- Allows for controlled selectedDate
- Allows for callback on navigation change (returns date)

clubhouse: https://app.clubhouse.io/hiclark/story/4075/smb-api-switch-calendar-view-over-to-graphql-handle-pagination-for-loading-old-sessions

### Quality Checklist:
These are mandatory and must be completed before merging the PR

- [ ] New, changed or refactored functionality has tests.
- [ ] New, changed or refactored functionality has documentation.
- [ ] New, changed or refactored functionality has been QA'd.
- [ ] New, changed or refactored functionality has been added to the CHANGELOG.
